### PR TITLE
Fix possibly-null type errors

### DIFF
--- a/src/Data/SendPropDefinition.ts
+++ b/src/Data/SendPropDefinition.ts
@@ -8,7 +8,7 @@ export class SendPropDefinition {
 	highValue: number;
 	bitCount: number;
 	table: SendTable|null;
-	numElements: number|null;
+	numElements: number;
 	arrayProperty: SendPropDefinition|null;
 	ownerTableName: string;
 
@@ -21,7 +21,7 @@ export class SendPropDefinition {
 		this.highValue      = 0;
 		this.bitCount       = 0;
 		this.table          = null;
-		this.numElements    = null;
+		this.numElements    = 0;
 		this.arrayProperty  = null;
 		this.ownerTableName = ownerTableName;
 	}

--- a/src/PacketHandler/PacketEntities.ts
+++ b/src/PacketHandler/PacketEntities.ts
@@ -94,7 +94,7 @@ function handleEntity(entity: PacketEntity, match: Match) {
 					}
 				}
 				if (prop.definition.ownerTableName === 'm_iAmmo') {
-					if (prop.value && prop.value > 0) {
+					if (prop.value !== null && prop.value > 0) {
 						player.ammo[parseInt(prop.definition.name, 10)] = <number>prop.value;
 					}
 				}

--- a/src/PacketHandler/PacketEntities.ts
+++ b/src/PacketHandler/PacketEntities.ts
@@ -94,7 +94,7 @@ function handleEntity(entity: PacketEntity, match: Match) {
 					}
 				}
 				if (prop.definition.ownerTableName === 'm_iAmmo') {
-					if (prop.value > 0) {
+					if (prop.value && prop.value > 0) {
 						player.ammo[parseInt(prop.definition.name, 10)] = <number>prop.value;
 					}
 				}


### PR DESCRIPTION
When I do a fresh clone + `make`, after the `npm install` succeeds, I get these type errors:

```
src/PacketHandler/PacketEntities.ts(97,10): error TS2531: Object is possibly 'null'.
src/Parser/SendPropParser.ts(37,11): error TS2531: Object is possibly 'null'.
```

This PR fixes those errors