### PR TITLE
Give ConsoleCmd a Packet type

### DIFF
--- a/src/Data/Packet.ts
+++ b/src/Data/Packet.ts
@@ -11,6 +11,11 @@ export interface StringTablePacket {
 	tables: StringTable[];
 }
 
+export interface ConsoleCmdPacket {
+	packetType: 'consoleCmd';
+	command: string;
+}
+
 export interface DataTablePacket {
 	packetType: 'dataTable';
 	tables: SendTable[];
@@ -149,4 +154,5 @@ export type Packet = BSPDecalPacket |
 	VoiceInitPacket |
 	VoiceDataPacket |
 	MenuPacket |
+	ConsoleCmdPacket |
 	CmdKeyValuesPacket;

--- a/src/Parser/Message/ConsoleCmd.ts
+++ b/src/Parser/Message/ConsoleCmd.ts
@@ -1,7 +1,11 @@
+import {ConsoleCmdPacket} from "../../Data/Packet";
 import {Parser} from './Parser';
 
 export class ConsoleCmd extends Parser {
-	parse() {
-		return this.stream.readUTF8String();
+	parse(): ConsoleCmdPacket[] {
+		return [{
+			packetType: 'consoleCmd',
+			command: this.stream.readUTF8String()
+		}];
 	}
 }

--- a/src/Parser/Message/Parser.ts
+++ b/src/Parser/Message/Parser.ts
@@ -21,5 +21,5 @@ export abstract class Parser {
 		this.skippedPackets = skippedPacket;
 	}
 
-	abstract parse(): Packet[]|string;
+	abstract parse(): Packet[];
 }


### PR DESCRIPTION
Just a suggestion.. Ran into this while trying to use this library; seems weird having one particular packet type not get parsed into a `Packet`