### PR TITLE
Fix BSPDecal parsing

### DIFF
--- a/src/Parser/Packet/BSPDecal.ts
+++ b/src/Parser/Packet/BSPDecal.ts
@@ -39,7 +39,7 @@ export function ParseBSPDecal(stream: BitStream): BSPDecalPacket { // 21: ParseB
 	const textureIndex = stream.readBits(9);
 	if (stream.readBoolean()) {
 		entIndex = stream.readBits(11);
-		modelIndex = stream.readBits(12);
+		modelIndex = stream.readBits(13);
 	}
 	const lowPriority = stream.readBoolean();
 


### PR DESCRIPTION
I was getting the same error in many demos after parsing BSPDecal packets so I decided to take a look.

https://github.com/VSES/SourceEngine2007/blob/43a5c90a5ada1e69ca044595383be67f40b33c61/src_main/common/netmessages.cpp#L533

Here the number of bits read for the model index is the constant SP_MODEL_INDEX_BITS, which in the 2013 SDK is 13: 

https://github.com/ValveSoftware/source-sdk-2013/blob/0d8dceea4310fde5706b3ce1c70609d72a38efdf/mp/src/public/const.h#L62

However currently only 12 bits are being read; changing it to 13 worked on the demos I tested.