### PR TITLE
Fixed node compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "bit-buffer": "^0.2.4",
     "snappyjs": "^0.6.0",
-    "text-encoding-shim": "git+https://gitlab.com/hongaar/text-encoding-shim.git#83ff0f77f48d05b8ce83ddc7ca49d8df61363b31"
+    "text-encoding-shim": "^1.0.5"
   },
   "devDependencies": {
     "@types/mocha": "^5.2.5",


### PR DESCRIPTION
As far as I can tell, the old dependency is a fork of the original text-encoding-shim with a patch that fixed compatibility with node.
The fork has been unmaintained for three years.
Since then, the original has been updated, making the fork obsolete.
Also, newer node versions have deprecated `GLOBAL` in favor of `global`.
This breaks compatibility with the fork and causes demos.tf to crash on node v16.2.0. The original has been updated to fix this incompatibility, see [this commit](https://gitlab.com/PseudoPsycho/text-encoding-shim/-/commit/142068f3a20b7038ab201fb49a4128198399b94f).